### PR TITLE
extend the asynchttp library to make it more flexible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,11 @@ env:
     secure: ENMA5XgK92+t5tia+tgiCSx2mrXSEwLKgbRkj7ZKezdCdH2Hq9/waf7zWyXxXZ3ZQOzvQEkzHDRULwoaareST4cTY365euHT7UW4uFEqFOfz2kk8HrCFkHPJnkXaosgBqGfwB7uxFpxqcFzaZ4YPcXdYdKEfqaz2Q7MJsQdXpqlFRWa3pmwMj8nu//b/0MRfRvQUya420jhHqyt4G8os+2/VcTt8XCi83nr/RaKSyAyVZLl/5zwvQPmv0TRt/VobvnxNGBpwFxzFhxF9JH0VS/h4Mu/j0QNSQ0Rg4ip8JzQxjzvdXmT4CVQX9f+42NrI7MmserpjSy8OZBRpUkfX0eTFWJL/pzgpYxdhW3/8dA0/IGoCj0kGmvoW0x4KSn8XKOPKJYZkdZwKSzNYMbqEDZY0rXS7AAnqVkoMjgz8JQcSfo17Lwvu+7bztK2/JnMQlkOxY+HNSaeACeKKxco24vrtvfoUW4xx0c3scju82NrngaiXrffLymbN4U5DoEP70Hd/BLeMfcP+34MDn+AOLBOeGTgU6nbziY9gZhlPdBGO6aG5PrwXEJDtnpQNU1Pe8/b8QYvIkWAY77cZlQfg6eQ27a/u5U5MLfCIH9kebERtsNyXqIoOnQXbIFma9m1UWr4L7FQSndmYnkbrMhIXvXEJdDghUtGEwvAaOlyj5MI=
 matrix:
   include:
-  - go: 1.2.2
-    env: OPTIONS=""
-  - go: 1.3.3
-    env: OPTIONS="-race"
-  - go: 1.4.2
+  - go: "1.10"
     env: COVERAGE="true" GOTOOLS="yes"
-  - go: 1.5
+  - go: 1.8.7
     env: OPTIONS="-race" GOTOOLS="yes"
 before_script:
-- if [[ "$GOTOOLS" = "yes" ]] ; then go get golang.org/x/tools/cmd/vet; fi
 - if [[ "$GOTOOLS" = "yes" ]] ; then go get golang.org/x/tools/cmd/cover; fi
 script:
 - if [[ "$GOTOOLS" = "yes" ]] ; then go fmt ./... | wc -l | grep 0 ; fi

--- a/asynchttp.go
+++ b/asynchttp.go
@@ -143,6 +143,16 @@ func (a *AsyncHttpManager) AsyncHttpRedirectFunc(w http.ResponseWriter,
 	http.Redirect(w, r, handler.Url(), http.StatusAccepted)
 }
 
+func (a *AsyncHttpManager) AsyncHttpRedirectUsing(w http.ResponseWriter,
+	r *http.Request,
+	id string,
+	handlerfunc func() (string, error)) {
+
+	handler := a.NewHandlerWithId(id)
+	handler.handle(handlerfunc)
+	http.Redirect(w, r, handler.Url(), http.StatusAccepted)
+}
+
 // Handler for asynchronous operation status
 // Register this handler with a router like Gorilla Mux
 //

--- a/asynchttp.go
+++ b/asynchttp.go
@@ -71,6 +71,8 @@ func (a *AsyncHttpManager) NewHandlerWithId(id string) *AsyncHttpHandler {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
+	_, idPresent := a.handlers[handler.id]
+	godbc.Require(!idPresent)
 	a.handlers[handler.id] = handler
 
 	return handler

--- a/asynchttp.go
+++ b/asynchttp.go
@@ -39,6 +39,7 @@ type AsyncHttpHandler struct {
 
 // Manager of asynchronous operations
 type AsyncHttpManager struct {
+	IdGen    func() string
 	lock     sync.RWMutex
 	route    string
 	handlers map[string]*AsyncHttpHandler
@@ -49,6 +50,7 @@ func NewAsyncHttpManager(route string) *AsyncHttpManager {
 	return &AsyncHttpManager{
 		route:    route,
 		handlers: make(map[string]*AsyncHttpHandler),
+		IdGen:    utils.GenUUID,
 	}
 }
 
@@ -56,7 +58,7 @@ func NewAsyncHttpManager(route string) *AsyncHttpManager {
 // Only use this function if you need to do every step by hand.
 // It is recommended to use AsyncHttpRedirectFunc() instead
 func (a *AsyncHttpManager) NewHandler() *AsyncHttpHandler {
-	return a.NewHandlerWithId(utils.GenUUID())
+	return a.NewHandlerWithId(a.NewId())
 }
 
 // NewHandlerWithId constructs and returns an AsyncHttpHandler with the
@@ -76,6 +78,12 @@ func (a *AsyncHttpManager) NewHandlerWithId(id string) *AsyncHttpHandler {
 	a.handlers[handler.id] = handler
 
 	return handler
+}
+
+// NewId returns a new string id for a handler. This string is not preserved
+// internally and must be passed to another function to be used.
+func (a *AsyncHttpManager) NewId() string {
+	return a.IdGen()
 }
 
 // Create an asynchronous operation handler and return the appropiate

--- a/asynchttp.go
+++ b/asynchttp.go
@@ -56,9 +56,16 @@ func NewAsyncHttpManager(route string) *AsyncHttpManager {
 // Only use this function if you need to do every step by hand.
 // It is recommended to use AsyncHttpRedirectFunc() instead
 func (a *AsyncHttpManager) NewHandler() *AsyncHttpHandler {
+	return a.NewHandlerWithId(utils.GenUUID())
+}
+
+// NewHandlerWithId constructs and returns an AsyncHttpHandler with the
+// given ID. Compare to NewHandler() which automatically generates its
+// own ID.
+func (a *AsyncHttpManager) NewHandlerWithId(id string) *AsyncHttpHandler {
 	handler := &AsyncHttpHandler{
 		manager: a,
-		id:      utils.GenUUID(),
+		id:      id,
 	}
 
 	a.lock.Lock()

--- a/asynchttp.go
+++ b/asynchttp.go
@@ -16,12 +16,13 @@
 package rest
 
 import (
-	"github.com/gorilla/mux"
-	"github.com/heketi/utils"
-	"github.com/lpabon/godbc"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/heketi/utils"
+	"github.com/lpabon/godbc"
 )
 
 var (


### PR DESCRIPTION
Extend the asynchttp lib, mostly around specifying/generating IDs, such that users of the library have more control over it.